### PR TITLE
CFY-5070 disable ~/.ssh/known_hosts checking by default

### DIFF
--- a/fabric_plugin/tasks.py
+++ b/fabric_plugin/tasks.py
@@ -61,7 +61,7 @@ FABRIC_ENV_DEFAULTS = {
     'pool_size': 0,
     'skip_bad_hosts': False,
     'status': False,
-    'disable_known_hosts': False,
+    'disable_known_hosts': True,
     'combine_stderr': True,
 }
 


### PR DESCRIPTION
When working in an environment where we expect the host key to change
often (eg. IaaS providers that often reuse the same ip for multiple
VMs), host key checking has an extremely high false positive rate.

This changeset disables host key checking by default.

Users can turn it back on by setting the disable_known_hosts fabric env
setting to False, or by providing their own known hosts file as the
system_known_hosts setting in the fabric env.