### PR TITLE
fix broken README useage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This plugin allows running SSH commands and Fabric Tasks remotely..
 
 ## Usage
 
-See [Fabric Plugin](http://getcloudify.org/guide/plugin-fabric.html)
+See [Fabric Plugin](http://docs.getcloudify.org/latest/plugins/fabric/)


### PR DESCRIPTION
simple update on verified link to http://docs.getcloudify.org/latest/plugins/fabric/ - fixes issue #42

I have verified that new link works and refers to proper documentation