### PR TITLE
Fix host_string for relationship context

### DIFF
--- a/fabric_plugin/tasks.py
+++ b/fabric_plugin/tasks.py
@@ -28,6 +28,7 @@ from fabric import context_managers as fabric_context
 
 import cloudify.ctx_wrappers
 from cloudify import ctx
+from cloudify import context
 from cloudify import utils
 from cloudify import exceptions
 from cloudify.decorators import operation
@@ -495,8 +496,13 @@ class CredentialsHandler():
         self.logger.debug('Retrieving host string...')
         if 'host_string' in self.fabric_env:
             host_string = self.fabric_env['host_string']
-        else:
+        elif self.ctx.type == context.NODE_INSTANCE:
             host_string = self.ctx.instance.host_ip
+        elif self.ctx.type == context.RELATIONSHIP_INSTANCE:
+            host_string = self.ctx.capabilities.instance.host_ip
+        else:
+            raise exceptions.NonRecoverableError(
+               'unknown host_string (host IP)')
         self.logger.debug('ssh host_string is: {0}'.format(host_string))
         return host_string
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,6 +4,6 @@
 plugins:
     fabric:
         executor: central_deployment_agent
-        source: https://github.com/cloudify-cosmo/cloudify-fabric-plugin/archive/1.5.1.zip
+        source: https://github.com/ICS-MU/westlife-cloudify-fabric-plugin/archive/master.zip
         package_name: cloudify-fabric-plugin
-        package_version: '1.5.1'
+        package_version: '1.5.1.1'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-fabric-plugin',
-    version='1.5.1',
+    version='1.5.1.1',
     author='Gigaspaces',
     author_email='cosmo-admin@gigaspaces.com',
     packages=['fabric_plugin'],


### PR DESCRIPTION
If Fabric task is used in relationship context and if `fabric_env` is missing `host_string` (host IP), the plugin fails during the attempt to get the `host_string` via calling the `self.ctx.instance.host_ip`. This call is valid only for node instance context, plugin fails on the following check:

```
context.py:
    def _verify_in_node_context(self):
        if self.type != NODE_INSTANCE:
            raise exceptions.NonRecoverableError(
                'ctx.node/ctx.instance can only be used in a {0} context but '
                'used in a {1} context.'.format(NODE_INSTANCE, self.type))
```

This simple patch brings separate handlings for node and relationship instance contexts.