### PR TITLE
Using private key: wrap in RSAKey

### DIFF
--- a/fabric_plugin/tasks.py
+++ b/fabric_plugin/tasks.py
@@ -25,12 +25,13 @@ from contextlib import contextmanager
 import requests
 from fabric import Connection, task
 from invoke import Task
+from paramiko import RSAKey
 
 import cloudify.ctx_wrappers
 from cloudify import ctx
 from cloudify import utils
 from cloudify import exceptions
-from cloudify._compat import exec_
+from cloudify._compat import exec_, StringIO
 from cloudify.decorators import operation
 from cloudify.proxy.client import CTX_SOCKET_URL
 from cloudify.proxy import client as proxy_client
@@ -78,7 +79,8 @@ def ssh_connection(ctx, fabric_env):
 
     connect_kwargs = {}
     if 'key' in fabric_env:
-        connect_kwargs['key'] = fabric_env.pop('key')
+        connect_kwargs['pkey'] = \
+            RSAKey.from_private_key(StringIO(fabric_env.pop('key')))
     elif 'key_filename' in fabric_env:
         connect_kwargs['key_filename'] = fabric_env.pop('key_filename')
     elif 'password' in fabric_env:

--- a/fabric_plugin/tests/test_fabric_plugin.py
+++ b/fabric_plugin/tests/test_fabric_plugin.py
@@ -305,8 +305,7 @@ class FabricPluginTest(BaseFabricPluginTest):
                       task_name='task',
                       fabric_env=fabric_env)
         kw = self._get_conn_kwargs()
-        self.assertEqual('explicit_key_content',
-                         kw['connect_kwargs']['key'])
+        self.assertIsInstance(kw['connect_kwargs']['pkey'], RSAKey)
 
     def test_implicit_user(self):
         fabric_env = self.default_fabric_env.copy()

--- a/fabric_plugin/tests/test_fabric_plugin.py
+++ b/fabric_plugin/tests/test_fabric_plugin.py
@@ -16,9 +16,11 @@ import os
 import unittest
 
 from invoke import Context
+from paramiko import RSAKey
 from mock import patch, MagicMock, Mock
 
 from cloudify import ctx
+from cloudify._compat import StringIO
 from cloudify.workflows import local
 from cloudify.decorators import workflow
 from cloudify.endpoint import LocalEndpoint
@@ -295,7 +297,10 @@ class FabricPluginTest(BaseFabricPluginTest):
 
     def test_explicit_key(self):
         fabric_env = self.default_fabric_env.copy()
-        fabric_env['key'] = 'explicit_key_content'
+        key_file = StringIO()
+        RSAKey.generate(2048).write_private_key(key_file)
+        key_file.seek(0)
+        fabric_env['key'] = key_file.read()
         self._execute('test.run_task',
                       task_name='task',
                       fabric_env=fabric_env)


### PR DESCRIPTION
passing `key` is just a typeerror. This is what fabric expects