### PR TITLE
Mark created wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The code is compatible with both python 2 and python 3,
so the generated wheels can be marked as universal, ie. working
with both.

Without this, if we build on py2, then we won't be able to install
on py3 (and the other way around)