### PR TITLE
Use a local compat module instead of cloudify._compat

### DIFF
--- a/fabric_plugin/_compat.py
+++ b/fabric_plugin/_compat.py
@@ -1,0 +1,40 @@
+########
+# Copyright (c) 2019 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+"""Python 2 + 3 compatibility utils"""
+# flake8: noqa
+
+import sys
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
+    exec("""
+def exec_(code, globs):
+    exec code in globs
+""")
+
+else:
+    from io import StringIO
+    exec_ = getattr(builtins, 'exec')
+
+
+__all__ = [
+    'StringIO', 'exec_'
+]

--- a/fabric_plugin/tasks.py
+++ b/fabric_plugin/tasks.py
@@ -31,7 +31,6 @@ import cloudify.ctx_wrappers
 from cloudify import ctx
 from cloudify import utils
 from cloudify import exceptions
-from cloudify._compat import exec_, StringIO
 from cloudify.decorators import operation
 from cloudify.proxy.client import CTX_SOCKET_URL
 from cloudify.proxy import client as proxy_client
@@ -39,6 +38,7 @@ from cloudify.proxy import server as proxy_server
 from cloudify.exceptions import NonRecoverableError
 
 from fabric_plugin import exec_env
+from fabric_plugin._compat import exec_, StringIO
 
 from cloudify.proxy.client import ScriptException
 

--- a/fabric_plugin/tests/test_fabric_plugin.py
+++ b/fabric_plugin/tests/test_fabric_plugin.py
@@ -20,7 +20,6 @@ from paramiko import RSAKey
 from mock import patch, MagicMock, Mock
 
 from cloudify import ctx
-from cloudify._compat import StringIO
 from cloudify.workflows import local
 from cloudify.decorators import workflow
 from cloudify.endpoint import LocalEndpoint
@@ -28,6 +27,7 @@ from cloudify.workflows import ctx as workflow_ctx
 from cloudify.exceptions import NonRecoverableError
 
 from fabric_plugin import tasks
+from fabric_plugin._compat import StringIO
 
 
 class BaseFabricPluginTest(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-fabric-plugin',
-    version='2.0.1',
+    version='2.0.2',
     author='Cloudify',
     author_email='hello@cloudify.co',
     packages=['fabric_plugin'],


### PR DESCRIPTION
Just for a 20 line compat module it's not really worth it
to require a 5.1 common

This just happens to allow the plugin to work with a 5.0.5
manager as well