### PR TITLE
More-Handling-CRLF

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.0.17: Add more handling for CRLF using strip lines
 2.0.16: RD-5466-improve-cloudify-fabric-plugin and orb fix
 2.0.15: Release dsl 1_4 yaml and redhat 8 wagon.
 2.0.14: Handle CRLF.

--- a/fabric_plugin/tasks.py
+++ b/fabric_plugin/tasks.py
@@ -722,6 +722,8 @@ def remove_crlf(script_path: str):
     """
     with io.open(script_path, 'rt', newline='') as f:
         lines = f.readlines()
+    for idx, line in enumerate(lines):
+        lines[idx] = "{0}\n".format(line.rstrip())
     with io.open(script_path, 'wt') as f:
         f.writelines(lines)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,4 +5,4 @@ plugins:
     fabric:
         executor: central_deployment_agent
         package_name: cloudify-fabric-plugin
-        package_version: '2.0.16'
+        package_version: '2.0.17'

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -1,0 +1,18 @@
+##################################################################################
+# Cloudify Fabric built in types and plugins definitions.
+##################################################################################
+plugins:
+    fabric:
+        executor: central_deployment_agent
+        package_name: cloudify-fabric-plugin
+        package_version: '2.0.17'
+
+blueprint_labels:
+  obj-type: 
+    values: 
+      - fabric
+
+labels:
+  obj-type: 
+    values: 
+      - fabric

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -5,7 +5,7 @@ plugins:
     fabric:
         executor: central_deployment_agent
         package_name: cloudify-fabric-plugin
-        package_version: '2.0.16'
+        package_version: '2.0.17'
 
 blueprint_labels:
   obj-type: 


### PR DESCRIPTION
testing the issue is quite simple , so in any simple blueprint , let's use vi 
```
vi script.sh -c "set ff=dos" -c ":wq"
```

it would fail 
```
Command: 'cd /tmp/cloudify-ctx/work && source /tmp/cloudify-ctx/scripts/env-print_file.sh-T4X10A5E && /tmp/cloudify-ctx/scripts/print_file.sh-T4X10A5E /tmp/stop.txt'

Exit code: 126

Stdout: already printed

Stderr: already printed
```
actual reason 
```
[ec2-user@ip-10-10-4-32 work]$ cd /tmp/cloudify-ctx/work && source /tmp/cloudify-ctx/scripts/env-print_file.sh-T4X10A5E && /tmp/cloudify-ctx/scripts/print_file.sh-T4X10A5E /tmp/stop.txt
-bash: /tmp/cloudify-ctx/scripts/print_file.sh-T4X10A5E: /bin/bash^M: bad interpreter: No such file or directory
```
